### PR TITLE
Make jigsaw hints consider current state

### DIFF
--- a/src/Todo.md
+++ b/src/Todo.md
@@ -10,10 +10,12 @@
 - multiplayer play or way to share?
 - errors/error boundaries
 - make styling per file
-- add install button https://web.dev/customize-install/
 - put on app stores (one app per game?)
 - add test to make sure common exclusion/additions don't share words
 - add way to share url with specific game settings
+- package code for use in daily palette
+- add install button https://web.dev/customize-install/
+- 
 
 ## Crossle
 
@@ -27,7 +29,7 @@
 - piece rotation
 - transpose grid/game solved logic will only work for square grid
 - allow to lock/unlock joined pieces?
-- not working on ipad?
+- make hints not reset whole puzzle if you have things that match
 
 ## Gribbles
 

--- a/src/jigsaw/logic/gameInit.js
+++ b/src/jigsaw/logic/gameInit.js
@@ -1,6 +1,45 @@
 import { generateGrid } from "./generateGrid";
 import { shuffleArray } from "../../common/shuffleArray";
 
+function getMaxShifts(grid) {
+  const transposedGrid = grid.map((_, index) => grid.map((row) => row[index]))
+
+  let maxShiftUp = 0
+  for (let index = 0; index < grid.length; index++) {
+    if (grid[index].every(i => i === "")) {
+      maxShiftUp++
+    } else { break }
+  }
+
+  let maxShiftDown = 0
+  for (let index = grid.length - 1; index >= 0; index--) {
+    if (grid[index].every(i => i === "")) {
+      maxShiftDown++
+    } else { break }
+  }
+
+  let maxShiftLeft = 0
+  for (let index = 0; index < transposedGrid.length; index++) {
+    if (transposedGrid[index].every(i => i === "")) {
+      maxShiftLeft++
+    } else { break }
+  }
+
+  let maxShiftRight = 0
+  for (let index = transposedGrid.length - 1; index >= 0; index--) {
+    if (transposedGrid[index].every(i => i === "")) {
+      maxShiftRight++
+    } else { break }
+  }
+
+  return {
+    maxShiftDown: maxShiftDown,
+    maxShiftLeft: maxShiftLeft,
+    maxShiftRight: maxShiftRight,
+    maxShiftUp: maxShiftUp,
+  }
+}
+
 function getPieceDimension(pieceData) {
   const maxTop = pieceData
     .map((data) => data.top)
@@ -59,8 +98,8 @@ function assemblePiece({ pieceData, rowIndex, colIndex }) {
   }
   return {
     letters: grid,
-    actualTop: rowIndex - topAdjust,
-    actualLeft: colIndex - leftAdjust,
+    solutionTop: rowIndex - topAdjust,
+    solutionLeft: colIndex - leftAdjust,
   };
 }
 
@@ -187,6 +226,8 @@ export function gameInit({ numLetters, useSaved = true }) {
     maxWordLength: maxWordLength,
   });
 
+  const {maxShiftLeft,maxShiftRight,maxShiftUp, maxShiftDown} = getMaxShifts(grid)
+
   const pieces = shuffleArray(makePieces(grid));
   const pieceData = pieces.map((piece, index) => ({
     letters: piece.letters,
@@ -194,14 +235,17 @@ export function gameInit({ numLetters, useSaved = true }) {
     boardTop: undefined,
     boardLeft: undefined,
     poolIndex: index,
-    actualTop: piece.actualTop,
-    actualLeft: piece.actualLeft,
+    solutionTop: piece.solutionTop,
+    solutionLeft: piece.solutionLeft,
   }));
 
   return {
     pieces: pieceData,
     gridSize: gridSize,
     numLetters: minLetters,
-    hintLevel: 0,
+    maxShiftLeft: maxShiftLeft,
+    maxShiftRight: maxShiftRight,
+    maxShiftUp: maxShiftUp,
+    maxShiftDown: maxShiftDown,
   };
 }


### PR DESCRIPTION
Instead of clearing the board and adding a new piece when you request a jigsaw hint, the game will not change the current solution if possible. A hint will realign the current pieces if needed or will add a new piece if no realignment of the current pieces is required.